### PR TITLE
fix: improve error handling and diagnostics for empty model responses

### DIFF
--- a/src/lib/openrouter.ts
+++ b/src/lib/openrouter.ts
@@ -29,11 +29,16 @@ export interface ChatCompletionRequest {
 export interface ChatCompletionChoice {
   index: number;
   message: ChatMessage;
+  finish_reason?: string;
 }
 
 export interface ChatCompletionResponse {
   id: string;
   choices: ChatCompletionChoice[];
+  error?: {
+    code?: string;
+    message?: string;
+  };
 }
 
 const DEFAULT_MODEL = process.env.OPENROUTER_DEFAULT_MODEL ?? "gpt-4o-mini";


### PR DESCRIPTION
## Summary

- Add detailed logging for empty model responses including completion ID, finish reason, choice, message, and error details
- Add specific error messages for common failure scenarios:
  - `content_filter`: Proposal contains flagged content
  - `length`: Response cut off due to length limits
  - Model-level errors with actionable guidance
- Extend TypeScript interfaces to include `finish_reason` and `error` fields in `ChatCompletionResponse`
- Improve user-facing error messages with clear, actionable information

## Context

This addresses a production issue where `openai/gpt-5` returns empty responses for some proposals. The enhanced error handling will provide better diagnostics to identify whether the issue is:
- Content filtering
- Token/length limits
- Model availability/configuration
- Other API-level errors

## Test plan

- [x] Verify TypeScript types compile correctly
- [x] Confirm error logging captures all relevant details
- [ ] Test in production to capture detailed error information for debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)