### PR TITLE
Rename CALL_TEXT to CALL_FOR_PROPOSAL_TEXT

### DIFF
--- a/src/app/api/synthetic/analyze/route.ts
+++ b/src/app/api/synthetic/analyze/route.ts
@@ -12,14 +12,14 @@ interface CharacteristicTuple {
 }
 
 const MAX_PROMPT_CHARS = 7000;
-const CALL_TEXT_PLACEHOLDER = "{{CALL_TEXT}}";
+const CALL_FOR_PROPOSAL_TEXT_PLACEHOLDER = "{{CALL_FOR_PROPOSAL_TEXT}}";
 const DEFAULT_PROMPT_TEMPLATE = `Analyze this call for proposals. Provide me a list of tuple variables I can sample from to generate synthetic proposals. For example the "submitter institution type" could be ("university", "startup", "large industry player", "non-profit", "FFRDC", "Federal entity").
 
 Be sure to extract all possible proposal topics. Also be sure to include anything that would lead to a proposal to "not be evaluated". Use concise option text. Each characteristic should have at least two options. Do not include explanations.
 
 Call for proposals text (truncated if necessary):
 """
-${CALL_TEXT_PLACEHOLDER}
+${CALL_FOR_PROPOSAL_TEXT_PLACEHOLDER}
 """`;
 
 const CHARACTERISTICS_SCHEMA = {
@@ -155,8 +155,8 @@ export async function POST(request: Request) {
     }
 
     const truncatedText = combinedText.slice(0, MAX_PROMPT_CHARS);
-    const promptWithText = promptTemplate.includes(CALL_TEXT_PLACEHOLDER)
-      ? promptTemplate.replace(CALL_TEXT_PLACEHOLDER, truncatedText)
+    const promptWithText = promptTemplate.includes(CALL_FOR_PROPOSAL_TEXT_PLACEHOLDER)
+      ? promptTemplate.replace(CALL_FOR_PROPOSAL_TEXT_PLACEHOLDER, truncatedText)
       : `${promptTemplate.trim()}\n\nCall for proposals text (truncated to ${MAX_PROMPT_CHARS.toLocaleString()} characters if necessary):\n"""\n${truncatedText}\n"""`;
 
     const messages: ChatMessage[] = [systemMessage, { role: "user", content: promptWithText }];

--- a/src/components/synthetic-proposal-generator.tsx
+++ b/src/components/synthetic-proposal-generator.tsx
@@ -31,7 +31,7 @@ const ACCEPTED_TYPES = [
   "text/plain",
 ];
 
-const ANALYSIS_TEXT_PLACEHOLDER = "{{CALL_TEXT}}";
+const ANALYSIS_TEXT_PLACEHOLDER = "{{CALL_FOR_PROPOSAL_TEXT}}";
 
 const DEFAULT_ANALYSIS_PROMPT = `Analyze this call for proposals. Provide me a list of tuple variables I can sample from to generate synthetic proposals. For example the "submitter institution type" could be ("university", "startup", "large industry player", "non-profit", "FFRDC", "Federal entity").
 
@@ -458,7 +458,12 @@ export function SyntheticProposalGenerator() {
 
           <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <h3 className="text-lg font-medium text-slate-900">Characteristics</h3>
+              <div>
+                <h3 className="text-lg font-medium text-slate-900">Characteristics</h3>
+                <p className="mt-1 text-xs text-slate-500">
+                  Default CFP: Semiconductor research and development proposals (various technical depths, budgets, and team qualifications)
+                </p>
+              </div>
               <div className="flex gap-2">
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
Improves variable naming clarity and adds a hint about the default CFP structure. The placeholder name now explicitly indicates it represents "Call for Proposal Text" rather than a generic "Call Text." Users are also informed that the default characteristics are based on semiconductor research and development proposals.

## Changes
- Rename `CALL_TEXT_PLACEHOLDER` to `CALL_FOR_PROPOSAL_TEXT_PLACEHOLDER` for better clarity
- Add descriptive hint under Characteristics heading explaining the default CFP domain
- Update all references to use the new placeholder name

🤖 Generated with [Claude Code](https://claude.com/claude-code)