### PR TITLE
Make proposal length a configurable characteristic

### DIFF
--- a/src/app/api/synthetic/route.ts
+++ b/src/app/api/synthetic/route.ts
@@ -50,7 +50,7 @@ const DEFAULT_USER_PROMPT_TEMPLATE = `Generate a realistic synthetic proposal wi
 
 {{CHARACTERISTICS_LIST}}
 
-The proposal should be 2-3 paragraphs long and reflect these characteristics authentically. Include:
+Reflect these characteristics authentically. Include:
 - A brief project overview
 - Key technical approaches or methodologies
 - Expected outcomes or deliverables

--- a/src/components/synthetic-proposal-generator.tsx
+++ b/src/components/synthetic-proposal-generator.tsx
@@ -25,7 +25,7 @@ const DEFAULT_USER_PROMPT_TEMPLATE = `Generate a realistic synthetic proposal wi
 
 {{CHARACTERISTICS_LIST}}
 
-The proposal should be 2-3 paragraphs long and reflect these characteristics authentically. Include:
+Reflect these characteristics authentically. Include:
 - A brief project overview
 - Key technical approaches or methodologies
 - Expected outcomes or deliverables
@@ -50,6 +50,14 @@ const DEFAULT_CHARACTERISTICS: CharacteristicTuple[] = [
       "Application of biotechnology and biomanufacturing technology for advanced microelectronics research and development",
       "commercialization of innovations",
       "standards development",
+    ],
+  },
+  {
+    name: "proposal length",
+    values: [
+      "1 page",
+      "5 pages",
+      "7 pages",
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Remove hard-coded "2-3 paragraphs" requirement from proposal generation prompt
- Add "proposal length" as a configurable characteristic with options: 1 page, 5 pages, 7 pages
- Users can now control proposal length through the UI or customize with their own values

🤖 Generated with [Claude Code](https://claude.com/claude-code)