### PR TITLE
Add .env.local copying to conductor setup

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,6 @@
+{
+    "scripts": {
+        "setup": "cp ../../.env.local .env.local",
+        "run": ""
+    }
+}


### PR DESCRIPTION
## Summary
Configure Conductor to automatically copy `.env.local` from the parent directory during workspace setup, ensuring environment variables are available when the workspace is initialized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)